### PR TITLE
feat(/posts) - sort user posts by date

### DIFF
--- a/controllers/posts.js
+++ b/controllers/posts.js
@@ -3,6 +3,7 @@ const Post = require("../models/post");
 const PostsController = {
   Index: (req, res) => {
     Post.find({})
+      .sort([['createdAt', -1]])
       .populate("author")
       .exec((err, posts) => {
         if (err) {

--- a/cypress/integration/posts_page_shows_date_spec.js
+++ b/cypress/integration/posts_page_shows_date_spec.js
@@ -13,25 +13,47 @@ describe("Timeline", () => {
     cy.get("#password").type("password");
     cy.get("#submit").click();
     
-    // submit a post
+    // submit multiple posts
     cy.visit("/posts");
     
     cy.contains("Make a post").click(); 
     cy.visit("/posts/new");
-    cy.get("#message").type("Cypress test post!");
+    cy.get("#message").type("Oldest post in this test!");
     cy.get("#submit").click();
 
+    cy.contains("Make a post").click(); 
+    cy.visit("/posts/new");
+    cy.get("#message").type("Middle post in this test!");
+    cy.get("#submit").click();
+
+    cy.contains("Make a post").click(); 
+    cy.visit("/posts/new");
+    cy.get("#message").type("Newest post in this test!");
+    cy.get("#submit").click();
+
+    // after redirection to /posts
+    cy.get(".post")
+      .first() // or .eq(0)
+      .should("contain", "Newest post in this test!");
+    
+    cy.get(".post")
+      .eq(1)
+      .should("contain", "Middle post in this test!");
+    
+    cy.get(".post")
+      .eq(2)
+      .should("contain", "Oldest post in this test!");
+    
     //Get the current date
     const date = new Date();
     var yyyy = date.getFullYear();
-
-    // Keeping following code for future reference/changes
+    
+    // // Keeping following code for future reference/changes
     // let options = {year: 'numeric', month: 'long', day: 'numeric' };
     // const dateString = Intl.DateTimeFormat('en-UK', options).format(date)
-
-    // visit a /posts page to check fr the result
-    cy.visit("/posts/");
-    cy.get(".posts").should("contain", "Cypress test post!");
+    
+    // temporary test to assert date
+    // when doing proper test should target the actual div class
     cy.get(".posts").should("contain", yyyy);
     // cy.get(".posts").should("contain", dateString);
   });

--- a/views/posts/index.hbs
+++ b/views/posts/index.hbs
@@ -1,10 +1,14 @@
 <h1>Timeline</h1>
 <ul class="posts">
   {{#each posts}}
-    <div class="post">
-      <li>{{this.author.name}}</li>
-      <li>{{this.createdAt}}</li>
-      <li>{{this.message}}</li>
-    </div>
+    <li>
+      <div class="post">
+        <ul>
+          <li>{{this.author.name}}</li>
+          <li>{{this.createdAt}}</li>
+          <li>{{this.message}}</li>
+        </ul>
+      </div>
+    </li>
   {{/each}}
 </ul>


### PR DESCRIPTION
- Corrected views/posts/index.hbs to now have each "post" div to actually be a <li> within the parent <ul>. And the items inside each "post" div to also be an <ul>
- This also helps to test for the sorting posts by date
- Added tests for date-sorted posts to existing integration test
- All existing tests pass
- We can check whether best to merge this PR or D's PR# 19 first
