### PR TITLE
reset comments on db reset, update one test

### DIFF
--- a/cypress/integration/posts_page_posts_ul_spec.js
+++ b/cypress/integration/posts_page_posts_ul_spec.js
@@ -21,6 +21,6 @@ describe("Timeline", () => {
     cy.get("#message").type("Cypress test post!");
     cy.get("#submit").click();
 
-    cy.get(".post:first > li").should("have.length", "5");
+    cy.get(".post:first > li").should("have.length", "6");
   });
 });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -35,4 +35,12 @@ module.exports = (on) => {
       return result;
     },
   });
+
+  on("task", {
+    emptyComments() {
+      mongoose.connect("mongodb://0.0.0.0/acebook_test");
+      const result = mongoose.connection.collection("comments").deleteMany({});
+      return result;
+    },
+  });
 };

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -23,4 +23,5 @@ beforeEach(() => {
   // cy.task("deleteAllItemsInDatabase");
   cy.task("emptyPosts");
   cy.task("emptyUsers");
+  cy.task("emptyComments");
 });

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -20,7 +20,6 @@
 require("./commands");
 
 beforeEach(() => {
-  // cy.task("deleteAllItemsInDatabase");
   cy.task("emptyPosts");
   cy.task("emptyUsers");
   cy.task("emptyComments");


### PR DESCRIPTION
Co-authored-by: 44jovi <kwong.jovi@gmail.com>

Added the comments to reset task before every cypress test and updated one of the tests to count the added comment.