### PR TITLE
adjust jest settings - makes all unit tests pass every time

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "nodemon ./bin/www",
     "start:test": "PORT=3030 MONGODB_URL='mongodb://0.0.0.0/acebook_test' npm start",
     "test": "npm run lint && npm run test:unit && npm run test:integration",
-    "test:unit": "jest",
+    "test:unit": "jest --runInBand --detectOpenHandles --forceExit",
     "test:integration": "cypress run"
   },
   "engines": {


### PR DESCRIPTION
Looks like tests from different files run in parallel and break each other. This seems to fix it, works on my machine, all unit tests pass all the time now. Maybe could be adjusted.