### PR TITLE
Fix post image overflow

### DIFF
--- a/controllers/posts.js
+++ b/controllers/posts.js
@@ -19,7 +19,7 @@ const PostsController = {
         }
         let postsWithInfo = [];
         posts.forEach((post) => {
-          postWithInfo = {
+          let postWithInfo = {
             ...post._doc,
           };
           const isNotLoggedInUsers =
@@ -33,7 +33,7 @@ const PostsController = {
           postWithInfo.displayLike = isNotLoggedInUsers && hasNotBeenLiked;
           postsWithInfo.push(postWithInfo);
         });
-        console.log(postsWithInfo);
+        // console.log(postsWithInfo);
         res.render("posts/index", { posts: postsWithInfo });
       });
   },

--- a/controllers/settings.js
+++ b/controllers/settings.js
@@ -24,7 +24,7 @@ const SettingsController = {
         console.log(err);
       } else {
         User.findById(req.session.user._id).then((user) => {
-          console.log(req.file);
+          // console.log(req.file);
           user.image = {
             data: req.file.buffer,
             contentType: req.file.mimetype,

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -30,7 +30,7 @@ const UsersController = {
           isNotOwnProfile: isNotOwnProfile,
         });
       })
-      .catch((err) => {
+      .catch(() => {
         res.render("error", { message: "This user does not exist" });
       });
   },

--- a/views/posts/index.hbs
+++ b/views/posts/index.hbs
@@ -73,7 +73,7 @@
                               <div class="row align-items-start">
                                 <div class="col-1">
                                   <img
-                                  class="author-comment-image"
+                                  class="author-comment-image" style="max-width:72px; max-height:72px"
                                   src="{{formatImage
                                     this.author.image.contentType
                                     this.author.image.data

--- a/views/posts/index.hbs
+++ b/views/posts/index.hbs
@@ -13,7 +13,7 @@
 
                 <div class="col-1">
                   <img
-                    class="author-post-image rounded"
+                    class="author-post-image rounded" style="max-width:72px; max-height:72px"
                     src="{{formatImage
                       this.author.image.contentType
                       this.author.image.data
@@ -29,7 +29,7 @@
 
                     {{#if this.image.data}}
                       <div><img
-                          class="post-image"
+                          class="post-image img-fluid"
                           src="{{formatImage this.image.contentType this.image.data}}"
                         /></div>
                       <br>


### PR DESCRIPTION
The images were bugging me, so here's a quick (inline css) fix with some direct styling. Fixed the linter errors on the way so I could run the full tests. Also, commented out console log statements that were logging the user info, including their password.
Eventually a proper bootstrap way of fixing the images to follow, or even better, limiting the upload size/dimensions or resizing them on upload.
Also, turns out it's really easy to do a new pull request to the team repo from a new fork :)